### PR TITLE
Add approx argument to connected_habitat function

### DIFF
--- a/src/grid.jl
+++ b/src/grid.jl
@@ -269,9 +269,12 @@ julia> ConScape.least_cost_distance(grid)
  3.11916   2.42602   1.73287   1.38629   3.46574   2.77259   1.38629   0.0
 ```
 """
-function least_cost_distance(g::Grid; θ::Nothing=nothing)
+function least_cost_distance(g::Grid; θ::Nothing=nothing, approx::Bool=false)
     # FIXME! This should be multithreaded. However, ProgressLogging currently
     # does not support multithreading
+    if approx
+        throw(ArgumentError("no approximate algorithm is available for this distance function"))
+    end
     targets = ConScape._targetidx_and_nodes(g)[1]
     @progress vec_of_vecs = [_least_cost_distance(g, target) for target in targets]
 

--- a/src/gridrsp.jl
+++ b/src/gridrsp.jl
@@ -299,7 +299,8 @@ end
         connectivity_function=expected_cost,
         distance_transformation=nothing,
         diagvalue=nothing,
-        θ::Union{Nothing,Real}=nothing)::Matrix{Float64}
+        θ::Union{Nothing,Real}=nothing,
+        approx::Bool=false)::Matrix{Float64}
 
 Compute RSP connected_habitat of all nodes. An inverse
 cost function must be passed for a `Grid` argument but is optional for `GridRSP`.
@@ -316,15 +317,18 @@ If `connectivity_function` is a `DistanceFunction`, then it is used for computin
 is converted to proximities using `distance_transformation`. If `connectivity_function` is a `ProximityFunction`,
 then proximities are computed directly using it. The default is `expected_cost`.
 
-For `Grid` object, the inverse temperature parameter `θ` must be passed when the `connectivity_function`
-requires it such as `expected_cost`.
+For `Grid` objects, the inverse temperature parameter `θ` must be passed when the `connectivity_function`
+requires it such as `expected_cost`. Also for `Grid` objects, the `approx` Boolean
+argument can be set to `true` to switch to a cheaper approximate solution of the
+`connectivity_function`. The default value is `false`.
 """
 function connected_habitat(
     grsp::Union{Grid,GridRSP};
     connectivity_function=expected_cost,
     distance_transformation=nothing,
     diagvalue=nothing,
-    θ::Union{Nothing,Real}=nothing)
+    θ::Union{Nothing,Real}=nothing,
+    approx::Bool=false)
 
     # Check that distance_transformation function has been passed if no cost function is saved
     if distance_transformation === nothing && connectivity_function <: DistanceFunction
@@ -341,7 +345,7 @@ function connected_habitat(
         if θ === nothing && connectivity_function !== least_cost_distance
             throw(ArgumentError("θ must be a positive real number when passing a Grid"))
         end
-        connectivity_function(grsp; θ=θ)
+        connectivity_function(grsp; θ=θ, approx=approx)
     else
         if θ !== nothing
             throw(ArgumentError("θ must be unspecified when passing a GridRSP"))

--- a/src/randomizedshortestpath.jl
+++ b/src/randomizedshortestpath.jl
@@ -324,7 +324,7 @@ function _bellman_ford_update_transposed!(c̄::Vector, φ::Vector, trPref::Spars
     end
     return c̄, φ
 end
-    
+
 # Helper function required for good performance until https://github.com/JuliaLang/julia/pull/42647 has been released
 function mygetindex(A::SparseMatrixCSC{Tv,Ti}, I::AbstractVector, J::Integer) where {Tv,Ti}
     if !issorted(I)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -339,21 +339,30 @@ end
 
         @testset "connected_habitat" begin
             @testset "expected_cost" begin
-                ch_rsp = ConScape.connected_habitat(grsp)
-                ch_g   = ConScape.connected_habitat(
-                    g; distance_transformation=ConScape.ExpMinus(),
+                ch_rsp = ConScape.connected_habitat(g_coarse_rsp)
+                ch_g = ConScape.connected_habitat(
+                    g_coarse;
+                    distance_transformation=ConScape.ExpMinus(),
                     θ=θ)
+                ch_g_approx = ConScape.connected_habitat(
+                    g_coarse;
+                    distance_transformation=ConScape.ExpMinus(),
+                    θ=θ,
+                    approx=true)
+
                 @test ch_g ≈ ch_rsp
+                @test ch_g ≈ ch_g_approx rtol=0.8 # Very rough approximation
             end
 
             @testset "least_cost_distance" begin
                 ch_rsp_lc = ConScape.connected_habitat(
                     g_coarse_rsp;
                     connectivity_function=ConScape.least_cost_distance)
-                ch_g_lc   = ConScape.connected_habitat(
+                ch_g_lc = ConScape.connected_habitat(
                     g_coarse;
                     connectivity_function=ConScape.least_cost_distance,
                     distance_transformation=ConScape.ExpMinus())
+
                 @test ch_g_lc ≈ ch_rsp_lc
             end
         end


### PR DESCRIPTION
This allows for the approximate version of the RSP based distances when computing `connected_habitat`