### PR TITLE
Fix: allocate fresh workspaces per task in threaded mode to avoid concurent mutation

### DIFF
--- a/src/windows.jl
+++ b/src/windows.jl
@@ -208,11 +208,16 @@ function init(wi::WindowedInit, i::Int; verbose=false)
     verbose && println("Initialising window from ranges $ranges...")
     rast = _get_window_with_zeroed_buffer(wi, ranges)
     # Pass pre-allocated workspaces to avoid repeated allocations
-    init(problem(problem(wi)), rast;
-        verbose,
-        workspaces=workspaces(wi),
-        sparse_builders=sparse_builders(wi),
-    )
+    # In threaded mode, each task allocates its own to avoid concurrent mutation
+    if problem(wi).threaded
+        init(problem(problem(wi)), rast; verbose)
+    else
+        init(problem(problem(wi)), rast;
+            verbose,
+            workspaces=workspaces(wi),
+            sparse_builders=sparse_builders(wi),
+        )
+    end
 end
 
 solve(p::WindowedProblem, rast::RasterStack; verbose=false, kw...) =


### PR DESCRIPTION
When using WindowedProblem with threaded=true, spawned window tasks were sharing pre-allocated WorkspaceCollection and SparseBuilders objects. Since Threads.@spawn doesn't guarantee thread affinity, multiple tasks could execute concurrently and access these shared mutable structures, causing ConcurrencyViolationError.

Solution: In threaded mode, each task allocates its own workspaces instead of reusing a shared pool. This eliminates concurrent access to mutable state while maintaining the pre-allocation optimization for single-threaded mode.

Fixes: ConcurrencyViolationError in WindowedProblem with threaded=true

Questions: (1) Does this undo what prealloaction was trying to solve? And, (2) how does this interact with the batch mode?